### PR TITLE
Distribution increments

### DIFF
--- a/squidlib-util/src/main/java/squidpony/squidmath/GaussianDistribution.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/GaussianDistribution.java
@@ -1,5 +1,3 @@
-package test;
-
 /*
 This is a port of the file rand/normal.go from
 https://github.com/golang/exp , which uses the following license:
@@ -32,6 +30,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+package squidpony.squidmath;
 /**
  * An IDistribution that produces double results with a Gaussian (normal) distribution. This means it has no limits in
  * any direction, but is much more likely to produce results close to 0. This now uses the Box-Muller Transform (it
@@ -41,7 +40,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * {@link IRNG#nextDouble()} (for every pair of outputs, it makes two calls to nextDouble()).
  * <br>
  * No argument constructor gives a mean of 0 and standard deviation and variance of 1 for an N(0,1) distribution
- * that Z Score tables are built around.
+ * that Z Score tables are built around. The two-argument constructor allows specifying a different mean and standard
+ * deviation. In statistics, mean is also called mu, and standard deviation is sigma squared.
  * <br>
  * Created by Tommy Ettinger on 11/23/2019, rewritten on 7/30/2020.
  */
@@ -55,7 +55,7 @@ public class GaussianDistribution implements IDistribution {
     
     /**
      * Creates a Gaussian (normal) distribution with mean of 0 and standard deviation and variance of 1.
-     * This N(0,1) probability distribution is what Z Score tables are built around.
+     * This N(0, 1) probability distribution is what Z Score tables are built around.
      */
     public GaussianDistribution() {
     	this.mu = 0;
@@ -64,7 +64,9 @@ public class GaussianDistribution implements IDistribution {
     
     /**
      * Creates a Gaussian (normal) distribution with specified mean and standard deviation.
-     * In statistics, this means providing the mu and sigma, respectively, for an N(mu, sigma^2) distribution.
+     * In statistics, this means providing the mu and sigma, respectively, for an N(mu, pow(sigma, 2)) distribution.
+     * @param mean (equivalent to mu) the value at the center of the distribution; also the most common result
+     * @param standardDeviation (equivalent to sigma squared) how far and often values should spread out away from the mean
      */
     public GaussianDistribution(double mean, double standardDeviation) {
     	this.mu = mean;

--- a/squidlib-util/src/main/java/squidpony/squidmath/GaussianDistribution.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/GaussianDistribution.java
@@ -40,8 +40,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * logarithm calculations, but it only needs to calculate every other number, and it uses a fixed amount of calls to
  * {@link IRNG#nextDouble()} (for every pair of outputs, it makes two calls to nextDouble()).
  * <br>
- * No argument constructor gives a mean of 0 and standard deviation and variance of 1 for N(0,1) that Z Score tables
- * are built around.
+ * No argument constructor gives a mean of 0 and standard deviation and variance of 1 for an N(0,1) distribution
+ * that Z Score tables are built around.
  * <br>
  * Created by Tommy Ettinger on 11/23/2019, rewritten on 7/30/2020.
  */
@@ -53,11 +53,19 @@ public class GaussianDistribution implements IDistribution {
     private final double mu;
     private final double sigma;
     
+    /**
+     * Creates a Gaussian (normal) distribution with mean of 0 and standard deviation and variance of 1.
+     * This N(0,1) probability distribution is what Z Score tables are built around.
+     */
     public GaussianDistribution() {
     	this.mu = 0;
     	this.sigma = 1;
     }
     
+    /**
+     * Creates a Gaussian (normal) distribution with specified mean and standard deviation.
+     * In statistics, this means providing the mu and sigma, respectively, for an N(mu, sigma^2) distribution.
+     */
     public GaussianDistribution(double mean, double standardDeviation) {
     	this.mu = mean;
     	this.sigma = standardDeviation;

--- a/squidlib-util/src/main/java/squidpony/squidmath/GaussianDistribution.java
+++ b/squidlib-util/src/main/java/squidpony/squidmath/GaussianDistribution.java
@@ -1,3 +1,5 @@
+package test;
+
 /*
 This is a port of the file rand/normal.go from
 https://github.com/golang/exp , which uses the following license:
@@ -30,8 +32,6 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package squidpony.squidmath;
-
 /**
  * An IDistribution that produces double results with a Gaussian (normal) distribution. This means it has no limits in
  * any direction, but is much more likely to produce results close to 0. This now uses the Box-Muller Transform (it
@@ -40,23 +40,37 @@ package squidpony.squidmath;
  * logarithm calculations, but it only needs to calculate every other number, and it uses a fixed amount of calls to
  * {@link IRNG#nextDouble()} (for every pair of outputs, it makes two calls to nextDouble()).
  * <br>
+ * No argument constructor gives a mean of 0 and standard deviation and variance of 1 for N(0,1) that Z Score tables
+ * are built around.
+ * <br>
  * Created by Tommy Ettinger on 11/23/2019, rewritten on 7/30/2020.
  */
 public class GaussianDistribution implements IDistribution {
     
     public static final GaussianDistribution instance = new GaussianDistribution();
-    
     private double cachedNext = 0.0;
     private boolean needsMore = true;
+    private final double mu;
+    private final double sigma;
+    
+    public GaussianDistribution() {
+    	this.mu = 0;
+    	this.sigma = 1;
+    }
+    
+    public GaussianDistribution(double mean, double standardDeviation) {
+    	this.mu = mean;
+    	this.sigma = standardDeviation;
+    }
     
     @Override
     public double nextDouble(IRNG rng) {
         if(needsMore ^= true)
             return cachedNext;
-        final double mul = Math.sqrt(-2.0 * Math.log(1.0 - rng.nextDouble()));
+        final double mul = sigma * Math.sqrt(-2.0 * Math.log(1.0 - rng.nextDouble()));
         final double variate = rng.nextDouble();
-        cachedNext = mul * NumberTools.cos_(variate);
-        return mul * NumberTools.sin_(variate);
+        cachedNext = mul * NumberTools.cos_(variate) + mu;
+        return mul * NumberTools.sin_(variate) + mu;
     }
 
     /**


### PR DESCRIPTION
The existing Gaussian distribution only computes probabilities for mean of 0 and standard deviation of 1 for N(0,1) distribution. That's the most common usage by far but I added a constructor to supply a different mean and standard deviation. The no argument constructor remains the N(0,1) distribution.

I studied the Box–Muller transform enough and tested with default java.util.Random to be confident in the addition of mu (mean) and sigma (standard variation) to the calculations. If you consider the extra multiplication and addition to be significant, it makes sense to have a separate nextDouble without them for N(0,1).

Allowing any (double) mean and standard deviation, it makes a lot of sense to be able to access what they are with get calls. However, I believe the author will add those from an extended interface.

I'd like to see nextDouble that doesn't need an IRNG implementation supplied that provides one under the hood for easier use for the statistics beginner.